### PR TITLE
Improvement in the regular expression that identifies the message to …

### DIFF
--- a/content_pack.json
+++ b/content_pack.json
@@ -110,7 +110,7 @@
       "title" : "Message",
       "type" : "REGEX",
       "configuration" : {
-        "regex_value" : "%.+-\\d+-.+: (.*)$"
+        "regex_value" : "%.+-\\d+-\\w: (.*)$"
       },
       "converters" : [ ],
       "order" : 7,


### PR DESCRIPTION
…logs that contain the character ":"

Some messages were not correctly captured. Changing "%.+-\d+-.+: (._)$" para "%.+-\d+-\w: (._)$" It allows you to capture messages containing ":" in your body such as: 

%SFF8472-5-THRESHOLD_VIOLATION: Te1/0/2: Rx power low warning; Operating value: -14.1 dBm, Threshold value: -14.1 dBm.
